### PR TITLE
Add an "Open in Gitpod" badge to the Readme

### DIFF
--- a/approvals-in-gitpod/README.md
+++ b/approvals-in-gitpod/README.md
@@ -1,5 +1,9 @@
 Report ApprovalTests diffs directly inside Gitpod
 
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/nitsanavni/katas)
+
+
 Read more about Gitpod [here](https://www.gitpod.io/docs/getting-started).
 
 Read more about ApprovalTests [here](https://github.com/approvals/ApprovalTests.Python).


### PR DESCRIPTION
Very cool demo, thanks!  This pull request includes a badge for opening in gitpod, to make it easier for visitors to find the link.

Best wishes,

Nick